### PR TITLE
Unnecessary dot

### DIFF
--- a/bridges_add_old
+++ b/bridges_add_old
@@ -160,7 +160,7 @@ case "$CHOICE" in
       i=1
       while [ $i -le $number_bridges ]
       do
-        bridge_address=$(whiptail --title "TorBox - INFO" --inputbox "\n\nInsert one bridge (something like:\nobfs4 xxx.xxx.xxx.xxx.:xxxx cert=abcd.. iat-mode=0)" $MENU_HEIGHT_15 $MENU_WIDTH_REDUX 3>&1 1>&2 2>&3)
+        bridge_address=$(whiptail --title "TorBox - INFO" --inputbox "\n\nInsert one bridge (something like:\nobfs4 xxx.xxx.xxx.xxx:xxxx cert=abcd.. iat-mode=0)" $MENU_HEIGHT_15 $MENU_WIDTH_REDUX 3>&1 1>&2 2>&3)
         bridge_address="$(<<< "$bridge_address" sed -e 's/[[:blank:]]*$//')"
         if [ -z "$bridge_address" ]; then
           trap "bash bridges_add_old $MODE_BRIDGES $STANDALONE; exit 0" EXIT


### PR DESCRIPTION
Wrong:
`xxx.xxx.xxx.xxx.:xxxx`

Correct:
`xxx.xxx.xxx.xxx:xxxx`