### PR TITLE
improve curl proxy method

### DIFF
--- a/lib/torbox.lib
+++ b/lib/torbox.lib
@@ -58,7 +58,7 @@ check_tor()
 clear
 echo -e "${RED}[+] Checking connectivity to the Tor network - please wait...${NOCOLOR}"
 sleep 1
-IS_TOR=$(curl --socks5 192.168.42.1:9050 --socks5-hostname 192.168.42.1:9050 -m 5 -s https://check.torproject.org/api/ip | grep -oP '"IsTor"\s*:\s*\K\w+')
+IS_TOR=$(curl -x socks5h://127.0.0.1:9050 -m 5 -s https://check.torproject.org/api/ip | grep -oP '"IsTor"\s*:\s*\K\w+')
 
 if [ $IS_TOR = true ]; then
   TOR_STATUS="TOR is working"
@@ -169,7 +169,7 @@ online_check()
   # Don't change it to "-z" !
   if [ "$CLEARNET_ONLY" == "0" ]; then
     #-m 6 must not be lower, otherwise it looks like there is no connection! ALSO IMPORTANT: THIS WILL NOT WORK WITH A CAPTCHA!
-    if curl --socks5 127.0.0.1:9050 --socks5-hostname 127.0.0.1:9050 -m 6 -s $CHECK_URL >/dev/null; then
+    if curl -x socks5h://127.0.0.1:9050 -m 6 -s $CHECK_URL >/dev/null; then
       OCHECK=1
       TORCONNECT=1
     else

--- a/update
+++ b/update
@@ -144,7 +144,7 @@ update_tor_preparations()
   if [ $TORCONNECT -eq 0 ]; then
     readarray -t torversion_versionsorted < <(curl --silent $TORURL | grep $TORPATH_TO_RELEASE_TAGS | sed -e "s|$TOR_HREF_FOR_SED||g" | sed -e "s/<a//g" | sed -e "s/\">//g" | sed -e "s/ //g" | sort -r)
   else
-    readarray -t torversion_versionsorted < <(curl --socks5 127.0.0.1:9050 --socks5-hostname 127.0.0.1:9050 --silent $TORURL | grep $TORPATH_TO_RELEASE_TAGS | sed -e $TOR_HREF_FOR_SED | sed -e "s/<a//g" | sed -e "s/\">//g" | sed -e "s/ //g" | sort -r)
+    readarray -t torversion_versionsorted < <(curl -x socks5h://127.0.0.1:9050 --silent $TORURL | grep $TORPATH_TO_RELEASE_TAGS | sed -e $TOR_HREF_FOR_SED | sed -e "s/<a//g" | sed -e "s/\">//g" | sed -e "s/ //g" | sort -r)
   fi
   #How many tor version did we fetch?
 	number_torversion=${#torversion_versionsorted[*]}


### PR DESCRIPTION
**Related issue / Why I want the change**
<!-- Insert the URL or '#n' (n being the number) -->
<!-- or explain why you want the change -->
* deprecating --socks5 option as it leaks dns requests https://tor.stackexchange.com/questions/3375/torsocks-curl-vs-curl-socks5/9462#9462

**Describe the changes**
<!-- A clear and concise description of what you did. -->
* using protocol socks5h, which is equivalent to --socks5-hostname
* -x, --proxy [protocol://]host[:port]  -- curl -x socks5h://127.0.0.1:9050
* it was probably not leaking because curl was using `--socks5` and `--socks5-hostname` after, which I think overrides
* unify curl host to be 127.0.0.1

**Extra**
Minimal curl version is 7.21.7
>The protocol support was added in curl 7.21.7
